### PR TITLE
Add ability to access model right after it's imported

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -260,7 +260,7 @@ class AppConfig:
         Raise LookupError if no model exists with this name.
         """
         if require_ready:
-            self.apps.check_models_ready()
+            self.apps.check_models_ready(model_name)
         else:
             self.apps.check_apps_ready()
         try:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -103,8 +103,14 @@ class RelatedField(FieldCacheMixin, Field):
 
     @cached_property
     def related_model(self):
-        # Can't cache this property until all the models are loaded.
-        apps.check_models_ready()
+        from django.db.models.base import Model
+        # Can't cache this property until related model is loaded.
+        if isinstance(self.remote_field.model, str):
+            apps.check_models_ready(self.remote_field.model)
+        elif isinstance(self.remote_field.model, type(Model)):
+            apps.check_models_ready(self.remote_field.model._meta.model_name)
+        else:
+            apps.check_models_ready()
         return self.remote_field.model
 
     def check(self, **kwargs):


### PR DESCRIPTION
Added so models can be accessed right after it's imported
and not after all models have been imported.
This will allow apps to access models from
apps that have a lower index number in `settings.INSTALLED_APPS`.